### PR TITLE
bug fix warning in dt_batch.m

### DIFF
--- a/Remoras/SPICE-Detector/detection/dt_batch.m
+++ b/Remoras/SPICE-Detector/detection/dt_batch.m
@@ -27,8 +27,7 @@ for idx1 = 1:N % for each data file
     hdr = io_readXWAVHeader(fullFiles{idx1}, pTemp,'fType', fTypes(idx1));
     
     if isempty(hdr)
-        warning(fprintf('No header info returned for file %s',...
-            currentRecFile));
+        warning('No header info returned for file %s',currentRecFile);
         disp('Moving on to next file')
         continue % skip if you couldn't read a header
         % Read the file header info


### PR DESCRIPTION
Hi @kfrasier, I just saw the  warning didn't work by giving the message with fprintf.
It should go directly like this:
warning('No header info returned for file %s',currentRecFile);