### PR TITLE
label1 nomenclature fix

### DIFF
--- a/Remoras/LabelVis/vis_Labels/lt_lVis_control.m
+++ b/Remoras/LabelVis/vis_Labels/lt_lVis_control.m
@@ -254,9 +254,9 @@ elseif strcmp(action,'Display')
         if strcmp(enabled,'on')
             checked = get(REMORA.lt.lVis_labels.label1Check,'Value');
             if checked
-                REMORA.lt.lVis_det.detection1.PlotLabels = true;
+                REMORA.lt.lVis_det.detection.PlotLabels = true;
             else
-                REMORA.lt.lVis_det.detection1.PlotLabels = false;
+                REMORA.lt.lVis_det.detection.PlotLabels = false;
             end
         else
             return


### PR DESCRIPTION
Issue found by Chelsea and Alba where loaded labels in the 'label1' position were being plotted regardless of whether checkbox was checked or not. Turned out to be a simple nomenclature issue that is fixed by this branch, which contains a single changed file. 