### PR TITLE
fix indexing associated with 'remove similar bins' post-processing option

### DIFF
--- a/Remoras/ClusterTool/cluster/ct_cc_modifyBinData.m
+++ b/Remoras/ClusterTool/cluster/ct_cc_modifyBinData.m
@@ -1,4 +1,4 @@
-function binDataFinal2 = ct_cc_modifyBinData(percSim,distThresh,binDataPruned,rmvClusMeanSpecs)
+function [binDataFinal2,fileNumFinal] = ct_cc_modifyBinData(percSim,distThresh,binDataPruned,rmvClusMeanSpecs,fileNum)
 
 %%created by MAZ on 06/09/2020 to try and remove undesirable clusters and
 %%things like them before reclustering
@@ -87,6 +87,7 @@ rmvFlag2(rmvFlag2==0)=[];
 goodOnes = setdiff([1:size(binDataPruned,1)],rmvFlag2);
 
 binDataFinal2 = binDataFinal(goodOnes);
+fileNumFinal = fileNum(goodOnes);
 
 %just gives number of bins where something was removed from it
 totalRemoved = length(rmvFlagFinal(rmvFlagFinal==1));

--- a/Remoras/ClusterTool/cluster/ct_composite_clusters.m
+++ b/Remoras/ClusterTool/cluster/ct_composite_clusters.m
@@ -115,7 +115,7 @@ if  tritonMode && isfield(REMORA.ct.CC,'rm_simbins')...
     %     thresh = 0.95;
     %     dist = 0.1;
     specComp = REMORA.ct.CC.sbSet;
-    binDataPruned = ct_cc_modifyBinData(REMORA.ct.CC_params.SBperc,REMORA.ct.CC_params.SBdiff,binDataPruned,specComp);
+    [binDataPruned,fileNum] = ct_cc_modifyBinData(REMORA.ct.CC_params.SBperc,REMORA.ct.CC_params.SBdiff,binDataPruned,specComp,fileNum);
 end
 % %%%%%%%%%% Begin main functionality %%%%%%%%%%%%
 %% Normalize everything


### PR DESCRIPTION
This is a fix for an issue I noticed in my cluster-based ID files where the times stored in zID were not matching up with time stored in the associated TPWS files. Turned out to be an issue with indexing when removing similar bins in composite clusters. 

Specifically, I was not passing fileNum into ct_cc_modifyBinData, so binDataPruned no longer correctly matched up with the file numbers after removing some of the bins. This is now fixed and seems to be working correctly. 
