### PR TITLE
Fix for ltsa and spec length not updating with loaded settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ Remoras/SPICE-Detector/settings/settings_detector_xwav_GOM_test.m
 *.cnf
 Settings/InstalledRemoras.cnf
 *.prj
+*.cp.txt

--- a/plot_ltsa.m
+++ b/plot_ltsa.m
@@ -168,6 +168,6 @@ end
 
 % change time in control window to data time in plot window
 set(HANDLES.ltsa.time.edtxt1,'String',timestr(PARAMS.ltsa.plot.dnum,6));
-set(HANDLES.ltsa.time.edtxt3,'String',PARAMS.ltsa.tseg.hr);
+% set(HANDLES.ltsa.time.edtxt3,'String',PARAMS.ltsa.tseg.hr);
 
 

--- a/plot_triton.m
+++ b/plot_triton.m
@@ -81,7 +81,7 @@ if multich_off
         set(HANDLES.time.edtxt1,'String',timestr(PARAMS.plot.dnum,6));
         %         end
         set(HANDLES.time.edtxt3,'String',timestr(PARAMS.plot.dnum,5));
-        set(HANDLES.time.edtxt4,'String',num2str(PARAMS.tseg.sec));
+%         set(HANDLES.time.edtxt4,'String',num2str(PARAMS.tseg.sec));
         %timestr doesn't do micro seconds with datenums so micro seconds are stored
         %in PARAMS.plot.uuu
         %   mmm = timestr(PARAMS.plot.dnum,5);


### PR DESCRIPTION
Plot lengths for the LTSA and the spectrogram were not being updated to what was specified in a saved settings/parameter file (.cp.txt). These two values were being replotted in plot_triton.m (spectrogram plot length, line 84) and in plot_ltsa.m (lotsa plot length, line 171) when other settings were being loaded (e.g., end frequency), so that when it came time to update these two settings, they had reverted back to the previous values. I commented out both of those lines as a work around. So far haven't had any issues with them being commented out. 