### PR TITLE
update parallel with number of workers if pool already exists

### DIFF
--- a/Remoras/SPICE-Detector/detection/sp_dt_batch.m
+++ b/Remoras/SPICE-Detector/detection/sp_dt_batch.m
@@ -25,7 +25,7 @@ else
     % deletes the current one and creates a new one with the specified
     % number of workers
     if poolobj.NumWorkers ~= p.parpool
-        disp('Shut down current pool to uptade number of workers specified')
+        disp('Shutting down current pool to update number of workers')
         delete(gcp('nocreate'))
         parpool(p.parpool)
     end


### PR DESCRIPTION
Fixed bug in the SPICE Detector with parallel pool. 
It assumed that no pool was created. Now it checks if a pool already exists, and if the number of workers of the current one is different from the workers specified, it closes the current one and creates a new one.