### PR TITLE
ensure spectra is normalized between 0 and 1

### DIFF
--- a/Remoras/NNet/funs/nn_fn_balanced_input_bin.m
+++ b/Remoras/NNet/funs/nn_fn_balanced_input_bin.m
@@ -70,8 +70,12 @@ for iD = 1:size(typeList,1)
     end
     [clusterTimes,I] = sort(clusterTimes);
     clusterSpectra = clusterSpectra(I,:);
-%     clusterSpectraMin = clusterSpectra-min(clusterSpectra,[],2);
-%     clusterSpectra = clusterSpectraMin./max(clusterSpectraMin,[],2);
+    
+    % make sure spectra is normalized between 0 and 1
+    if min(min(clusterSpectra)) > 1
+        clusterSpectraMin = clusterSpectra-min(clusterSpectra,[],2);
+        clusterSpectra = clusterSpectraMin./max(clusterSpectraMin,[],2);
+    end
     clusterICI = clusterICI(I,:);
     if ~isempty(clusterWave)
         clusterWave = clusterWave(I,:);


### PR DESCRIPTION
added a check spot to get all features normalized between 0 and 1. Spectra was normalized between 1 and 2 and was saturated when plotting all features together.