### PR TITLE
batchLTSA remora - skip dirs improvement

### DIFF
--- a/Remoras/BatchLTSA/batchLTSA_chk_ltsa_params.m
+++ b/Remoras/BatchLTSA/batchLTSA_chk_ltsa_params.m
@@ -1,6 +1,8 @@
 function batchLTSA_chk_ltsa_params(dirs) 
 
 global REMORA
+
+disp_msg('Check LTSA settings for each directory. To skip, set tave and dfreq blank.');
 % creates gui window to define ltsa settings
 mycolor = [.8,.8,.8];
 r = length(dirs) + 2;
@@ -83,9 +85,18 @@ global PARAMS
 % close figure and assign values
 PARAMS.ltsa.taves = zeros(length(fig_taves), 1);
 PARAMS.ltsa.dfreqs = zeros(length(fig_dfreqs), 1);
-for d = 1:length(fig_taves)
+for d = 1:length(fig_taves)      
     PARAMS.ltsa.taves(d) = str2double(get(fig_taves{d}, 'String'));
     PARAMS.ltsa.dfreqs(d) = str2double(get(fig_dfreqs{d}, 'String'));
+end
+
+%id any blank/dirs to skip
+dirToSkip = isnan(PARAMS.ltsa.taves) & isnan(PARAMS.ltsa.dfreqs);
+if any(dirToSkip)
+    PARAMS.ltsa.indirs = PARAMS.ltsa.indirs(~dirToSkip);
+    PARAMS.ltsa.outdirs = PARAMS.ltsa.outdirs(~dirToSkip);
+    PARAMS.ltsa.taves = PARAMS.ltsa.taves(~dirToSkip);
+    PARAMS.ltsa.dfreqs = PARAMS.ltsa.dfreqs(~dirToSkip);
 end
 close(fig);
 end

--- a/Remoras/BatchLTSA/batchLTSA_mk_batch_ltsa.m
+++ b/Remoras/BatchLTSA/batchLTSA_mk_batch_ltsa.m
@@ -14,14 +14,14 @@ dfreqs =    PARAMS.ltsa.dfreqs;
 % loop through each of the sets of directories for actual ltsa creation
 for k = 1:length(indirs)
     lIdx = k; % which LTSA (For progress bar)
-        
+    
     PARAMS.ltsa.indir = char(indirs{k});
     PARAMS.ltsa.outdir = char(outdirs{k});
     PARAMS.ltsa.outfile = char(outfiles{k});
     PARAMS.ltsa.tave = taves(k);
     PARAMS.ltsa.dfreq = dfreqs(k);
-        
-    % run from matlab command line 
+    
+    % run from matlab command line
     if ~isfield(REMORA, 'hrp') % the *else* below isn't tested...carry over from Ann Allen*
         d = dirdata{k};
         if ~isfield(d, 'dataID') % non xwav/typical dir
@@ -36,8 +36,11 @@ for k = 1:length(indirs)
     end
     
     % make the ltsa!
+    disp_msg(sprintf('Creating LTSA %i/%i: %s.', lIdx, length(PARAMS.ltsa.indirs), ...
+        PARAMS.ltsa.indir));
     batchLTSA_mk_ltsa_dir(lIdx);
     fprintf('Finished LTSA for directory %s\n', PARAMS.ltsa.indir)
+    disp_msg(sprintf('Finished LTSA %i/%i.', lIdx, length(PARAMS.ltsa.indirs)));
     % fprintf('Press any key to continue...\n')
     %     pause
 end % all directories

--- a/Remoras/BatchLTSA/batchLTSA_mk_batch_ltsa_precheck.m
+++ b/Remoras/BatchLTSA/batchLTSA_mk_batch_ltsa_precheck.m
@@ -45,6 +45,8 @@ PARAMS.ltsa.outdirs = outdirs;
 batchLTSA_chk_ltsa_params(indirs); % set taves and dfreqs
 taves = PARAMS.ltsa.taves;
 dfreqs = PARAMS.ltsa.dfreqs;
+indirs = PARAMS.ltsa.indirs;
+outdirs = PARAMS.ltsa.outdirs;
 
 % % raw files to skip.
 % % * this is specific to HRPs?


### PR DESCRIPTION
added ability to skip some directories within a higher level folder of dirs. To skip, just change taves and dfreqs to blanks during the 'parameter check' GUI. Directions are listed in message window using `disp_msg`