### PR TITLE
Fix bug when zeropadding wav files

### DIFF
--- a/calc_ltsa.m
+++ b/calc_ltsa.m
@@ -146,8 +146,11 @@ for k = 1:PARAMS.ltsa.nxwav            % loop over all xwavs
             if dsz < PARAMS.ltsa.nfft
                 %                 dz = zeros(PARAMS.ltsa.nfft-nsamp,1);
                 dz = zeros(PARAMS.ltsa.nfft-dsz,1);
-                               data = [data,dz'];
-                %  data = [data,dz'];
+                if size(data,1) == 1 % row vector, typical for xwav 
+                    data = [data,dz'];
+                elseif size(data,2) == 1 % column vector, typical for wav/flac
+                    data = [data;dz];
+                end
                 disp(['File# Raw# Ave# DataSize: ',num2str(k),'  ',num2str(r),'  ',num2str(n),'  ',num2str(dsz)])
                 %                 disp('Paused ... press any key to continue')
                 % pause


### PR DESCRIPTION
WAV/FLAC gets read in as column vector, but XWAV gets read in as row vector, so can cause issues with concatenating the zeros. If/else statement checks size of 'data' and concatenates accordingly. 

This is a cleaned-up version of #86 (many new additions to Triton made the commits a mess, will close) where this pull request only includes a single file change/commit. 

Fixes issue flagged in #85 and related to #83. 