### PR TITLE
update nn_fn_standardize_data

### DIFF
--- a/Remoras/NNet/funs/nn_fn_standardize_data.m
+++ b/Remoras/NNet/funs/nn_fn_standardize_data.m
@@ -1,42 +1,54 @@
-function [dataInput,trainTestSetInfo] = nn_fn_standardize_data(trainTestSetInfo,dataInput, trainTF)
-    % trainTF should be true if you want to update trainTestSetInfo values,
-    % false otherwise.
+function [dataOutput,trainTestSetInfo] = nn_fn_standardize_data(trainTestSetInfo,dataInput, trainTF)
+% trainTF should be true if you want to update trainTestSetInfo values,
+% false otherwise.
+
+dataOutput = nan(size(dataInput)); % preallocate the output data, in case we're not using spectra ICI and waveform
+
+if trainTestSetInfo.useSpectra
+
     if trainTF
         trainTestSetInfo.specStd = [mean(min(dataInput(:,1:trainTestSetInfo.setSpecHDim),[],2)),mean(max(dataInput(:,1:trainTestSetInfo.setSpecHDim),[],2))];
     end
     normSpec1 = dataInput(:,1:trainTestSetInfo.setSpecHDim)-trainTestSetInfo.specStd(1);
-    dataInput(:,1:trainTestSetInfo.setSpecHDim) = normSpec1./(trainTestSetInfo.specStd(2)-trainTestSetInfo.specStd(1));
+    dataOutput(:,1:trainTestSetInfo.setSpecHDim) = normSpec1./(trainTestSetInfo.specStd(2)-trainTestSetInfo.specStd(1));
+
+end
+
+if trainTestSetInfo.useICI % if we have selected to use ICI
 
     ICIstart = trainTestSetInfo.setSpecHDim+1;
-    
     if max(dataInput(:,ICIstart:(ICIstart+trainTestSetInfo.setICIHDim-1)),[],'all')>1 ...
-        && trainTestSetInfo.iciStd>1
+            && trainTestSetInfo.iciStd>1
         if trainTF
             trainTestSetInfo.iciStd = mean(max(dataInput(:,ICIstart:(ICIstart+trainTestSetInfo.setICIHDim-1)),[],2));
         end
-        dataInput(:,ICIstart:(ICIstart+trainTestSetInfo.setICIHDim-1)) = ...
+        dataOutput(:,ICIstart:(ICIstart+trainTestSetInfo.setICIHDim-1)) = ...
             dataInput(:,ICIstart:(ICIstart+trainTestSetInfo.setICIHDim-1))/...
             trainTestSetInfo.iciStd(1);
     elseif max(dataInput(:,ICIstart:(ICIstart+trainTestSetInfo.setICIHDim-1)),[],'all')>1 ...
-        && trainTestSetInfo.iciStd<=1
+            && trainTestSetInfo.iciStd<=1
 
-        dataInput(:,ICIstart:(ICIstart+trainTestSetInfo.setICIHDim-1)) = ...
+        dataOutput(:,ICIstart:(ICIstart+trainTestSetInfo.setICIHDim-1)) = ...
             dataInput(:,ICIstart:(ICIstart+trainTestSetInfo.setICIHDim-1))./...
             max(dataInput(:,ICIstart:(ICIstart+trainTestSetInfo.setICIHDim-1)),[],2);
     else
-       warning('ICI appears to be already normalized to [0,1] skipping standardization')
-       trainTestSetInfo.iciStd = 1;
+        warning('ICI appears to be already normalized to [0,1] skipping standardization')
+        dataOutput(:,ICIstart:(ICIstart+trainTestSetInfo.setICIHDim-1)) = dataInput(:,ICIstart:(ICIstart+trainTestSetInfo.setICIHDim-1));
+        trainTestSetInfo.iciStd = 1;
     end
     % check icis for infs and nans
-    tempICI = dataInput(:,ICIstart:(ICIstart+trainTestSetInfo.setICIHDim-1));
+    tempICI = dataOutput(:,ICIstart:(ICIstart+trainTestSetInfo.setICIHDim-1));
     tempICI(isnan(tempICI)) = 0;
     tempICI(isinf(tempICI)) = 0;
-    dataInput(:,ICIstart:(ICIstart+trainTestSetInfo.setICIHDim-1)) = tempICI;
+    dataOutput(:,ICIstart:(ICIstart+trainTestSetInfo.setICIHDim-1)) = tempICI;
 
+end
+
+if trainTestSetInfo.useWave % if we've selected to use waveform
 
     wavestart = trainTestSetInfo.setSpecHDim+trainTestSetInfo.setICIHDim+1;
-    if trainTF 
-        
+    if trainTF
+
         trainTestSetInfo.waveMed = median(max(dataInput(:,wavestart:(wavestart+trainTestSetInfo.setWaveHDim-1)),[],2));
         trainTestSetInfo.waveMode = mode(max(dataInput(:,wavestart:(wavestart+trainTestSetInfo.setWaveHDim-1)),[],2));
 
@@ -45,13 +57,19 @@ function [dataInput,trainTestSetInfo] = nn_fn_standardize_data(trainTestSetInfo,
     if trainTestSetInfo.waveMode==1 % sometimes most of the waveforms are normalized to 1, if so, make them all that way.
         trainTestSetInfo.maxWave = max( dataInput(:,wavestart:(wavestart+trainTestSetInfo.setWaveHDim-1)),[],2);
 
-        dataInput(:,wavestart:(wavestart+trainTestSetInfo.setWaveHDim-1)) = dataInput(:,wavestart:(wavestart+trainTestSetInfo.setWaveHDim-1))./trainTestSetInfo.maxWave;
-    
+        dataOutput(:,wavestart:(wavestart+trainTestSetInfo.setWaveHDim-1)) = dataInput(:,wavestart:(wavestart+trainTestSetInfo.setWaveHDim-1))./trainTestSetInfo.maxWave;
+
     else % otherwise divide by the training set median.
-        dataInput(:,wavestart:(wavestart+trainTestSetInfo.setWaveHDim-1)) = dataInput(:,wavestart:(wavestart+trainTestSetInfo.setWaveHDim-1))./trainTestSetInfo.waveMed;
+        dataOutput(:,wavestart:(wavestart+trainTestSetInfo.setWaveHDim-1)) = dataInput(:,wavestart:(wavestart+trainTestSetInfo.setWaveHDim-1))./trainTestSetInfo.waveMed;
 
     end
-    % optional neighbordata section
-    neighborWidth = size(dataInput,2)-trainTestSetInfo.setWaveHDim-...
-        trainTestSetInfo.setICIHDim-trainTestSetInfo.setSpecHDim;
-    dataInput(:,(end-neighborWidth):end) = dataInput(:,(end-neighborWidth):end)/20;
+
+end
+
+% optional neighbordata section
+neighborWidth = size(dataInput,2)-trainTestSetInfo.setWaveHDim-...
+    trainTestSetInfo.setICIHDim-trainTestSetInfo.setSpecHDim;
+dataOutput(:,(end-neighborWidth):end) = dataOutput(:,(end-neighborWidth):end)/20;
+
+% now, remove columns of nans - will prevent dimension errors in predicting
+dataOutput(:, all(isnan(dataOutput), 1)) = [];


### PR DESCRIPTION
minor modifications to fix errors when you're not training or classifying using all three parameters (spectra, ICI, waveform):
1. update function to only standardize variables that you're training/classifying on. added if statements to check trainTestSetInfo to see if variables are selected before standardizing. this fixes dimension errors within this function if you're not using all three parameters.
2. update output to ONLY include data related to variables that you're training/classifying on. created a dataOutput variable which is subsetted accordingly based on the parameters you've selected to use, rather than outputting a standardized version of dataInput as previously. this fixes dimension errors in the predict() function on line 123 of nn_fn_classify_bins if you're not using all three parameters.