### PR TITLE
update readseg.m

### DIFF
--- a/readseg.m
+++ b/readseg.m
@@ -15,9 +15,6 @@ DATA = [];  % clear DATA vector
 
 fullfname = fullfile(PARAMS.inpath,PARAMS.infile);
 
-% commented out to get rid of the global mDATA variable, doesn't matter now if
-% multich button is on or not, program reads DATA in DATA(:,ch) 
-
 % if multich_on % multi channel mode! read all channels into a MATRIX
 %     if PARAMS.ftype == 1        % wav file
 %         [ m d ] = wavfinfo(fullfname);
@@ -92,43 +89,80 @@ fullfname = fullfile(PARAMS.inpath,PARAMS.infile);
         DATA = double(DATA);
 %         DATA = DATA(:,PARAMS.ch).*2^15;     % un-normalize wavread
     elseif PARAMS.ftype == 2    % xwav file
-        index = PARAMS.raw.currentIndex;
-        if PARAMS.nBits == 16
-            dtype = 'int16';
-        elseif PARAMS.nBits == 24
-            dtype = 'int24';
-        elseif PARAMS.nBits == 32
-            dtype = 'int32';
-        else
-            disp_msg('PARAMS.nBits = ')
-            disp_msg(PARAMS.nBits)
-            disp_msg('not supported')
-            return
+    if PARAMS.nBits == 16
+        dtype = 'int16';
+    elseif PARAMS.nBits == 24
+        dtype = 'int24';
+    elseif PARAMS.nBits == 32
+        dtype = 'int32';
+    else
+        disp_msg('PARAMS.nBits = ')
+        disp_msg(PARAMS.nBits)
+        disp_msg('not supported')
+        return
+    end
+
+    PARAMS.tseg.samp = ceil( PARAMS.tseg.sec * PARAMS.fs );  % number of samples in segment
+
+    fid = fopen(fullfname,'r');            % open once, reused across the rest of the code
+
+    segIdx = PARAMS.raw.currentIndex;      % raw segment containing the window's start time
+    samplesNeeded = PARAMS.tseg.samp;      % how many samples we still owe the window
+    DATA = [];                              
+    raw_end_times = [];                     % one real boundary per segment crossed
+    readStartDnum = PARAMS.plot.dnum;       % calendar time this chunk's read should start at
+
+    while samplesNeeded > 0 && segIdx <= numel(PARAMS.raw.dnumStart)
+
+        % how many samples into THIS segment does our read start point fall?
+        skip = round((readStartDnum - PARAMS.raw.dnumStart(segIdx)) * 24*60*60 * PARAMS.fs);
+
+        % how many samples does this segment actually have left, from here to its own true end?
+        segSamplesAvail = round((PARAMS.raw.dnumEnd(segIdx) - readStartDnum) * 24*60*60 * PARAMS.fs);
+
+        samplesToRead = min(samplesNeeded, segSamplesAvail);   % never read past this segment's real end
+
+        fseek(fid, PARAMS.xhd.byte_loc(segIdx) + skip*PARAMS.nch*PARAMS.samp.byte, 'bof');
+        chunk = fread(fid, [PARAMS.nch, samplesToRead], dtype)';
+        DATA = [DATA; chunk];                                   % tack this segment's audio onto the window
+
+        samplesNeeded = samplesNeeded - samplesToRead;
+
+        raw_end_times(end+1) = (PARAMS.raw.dnumEnd(segIdx) - PARAMS.plot.dnum) * 60*60*24;
+                                                                  % this segment's real boundary, for the marker line
+
+        if samplesNeeded > 0                                    % window still isn't full
+            if segIdx == numel(PARAMS.raw.dnumStart)
+                % no raw segments left at all -- pad the remainder so the plot still spans the GUI's requested length
+                disp_msg('Reached the end of the last raw file before filling the plot window; padding remainder');
+                DATA = [DATA; zeros(samplesNeeded, PARAMS.nch)];
+                samplesNeeded = 0;
+                break
+            end
+
+            gapSec = (PARAMS.raw.dnumStart(segIdx+1) - PARAMS.raw.dnumEnd(segIdx)) * 24*60*60;
+            if gapSec >  1/PARAMS.fs % setting the need for padding based on any time skip that is smaller than one sample's worth of time (similar to check_time.m)
+                % real recording gap -- pad just the missing duration, then keep reading real audio after it
+                disp_msg('Recording gap encountered mid plot window; padding the gap to preserve requested plot length');
+                gapSamples = min(round(gapSec * PARAMS.fs), samplesNeeded);
+                DATA = [DATA; zeros(gapSamples, PARAMS.nch)];
+                samplesNeeded = samplesNeeded - gapSamples;
+            end
+
+            if samplesNeeded > 0
+                segIdx = segIdx + 1;                             % move on to the next segment and keep collecting
+                readStartDnum = PARAMS.raw.dnumStart(segIdx);
+            end
         end
-        skip = floor((PARAMS.plot.dnum - PARAMS.raw.dnumStart(index)) * 24 * 60 * 60 * PARAMS.fs);   % number of samples to skip over
-        % %
-        PARAMS.tseg.samp = ceil( PARAMS.tseg.sec * PARAMS.fs );	% number of samples in segment
-        fid = fopen(fullfname,'r');
-        fseek(fid,PARAMS.xhd.byte_loc(index) + skip*PARAMS.nch*PARAMS.samp.byte,'bof');
-        DATA = fread(fid,[PARAMS.nch,PARAMS.tseg.samp],dtype)';
-        fclose(fid);
-%         DATA = DATA(PARAMS.ch,:);
-        if PARAMS.xgain > 0
-            DATA(:,PARAMS.ch) = DATA(:,PARAMS.ch) ./ PARAMS.xgain(1);
-        end
-        % calculate where the first raw file ends in the current plot
-        raw_end_times(1) = (PARAMS.raw.dnumEnd(PARAMS.raw.currentIndex) - PARAMS.plot.dnum)...
-          * 60 * 60 * 24;
-        % assuming that all raw files are the same length
-        bytes_on_plot = PARAMS.tseg.sec*PARAMS.xhd.ByteRate(1);
-        % how many bytes are left after the first raw file ends
-        bytes_left = bytes_on_plot - raw_end_times(1)*PARAMS.xhd.ByteRate(1);%PARAMS.fs*2;
-        if bytes_left > 0 % only true when two raw files in plot
-          seconds_per_raw = PARAMS.xhd.byte_length(1)/PARAMS.xhd.ByteRate(1);
-          num_of_raw = ceil((PARAMS.tseg.sec - raw_end_times(1))/seconds_per_raw) + 1; % +1 for first rawfile
-          raw_end_times(2:num_of_raw) = raw_end_times(1) + [1:num_of_raw-1]*seconds_per_raw;
-        end
-        PARAMS.raw.delimit_time = raw_end_times;
+    end
+
+    fclose(fid);
+
+    if PARAMS.xgain > 0
+        DATA(:,PARAMS.ch) = DATA(:,PARAMS.ch) ./ PARAMS.xgain(1);
+    end
+
+    PARAMS.raw.delimit_time = raw_end_times;
         %calculate micro seconds skipped since time resolution is too low
     %     micro_samples = mod(skip,PARAMS.fs/1000);
     %     if micro_samples < PARAMS.fs/1000 && micro_samples ~= 0


### PR DESCRIPTION
readseg.m currently reads the raw file header to plot spectrograms. however, if multiple raw files were displayed in a spectrogram, only 1 raw file header was being read and assuming all raw files were the same length. when you have variable gaps between raw files (ex: created by buffer wrap around), each raw file header being displayed in the spectrogram needs to be read. this now accounts for reading the headers of each raw file in displayed spectrograms and pads the spectrogram at the start/end when raw files are not the full duration.